### PR TITLE
DEV: Convert component to a glimmer component

### DIFF
--- a/javascripts/discourse/components/custom-category-boxes.hbs
+++ b/javascripts/discourse/components/custom-category-boxes.hbs
@@ -638,7 +638,7 @@
   {{else}}
 
     <span class="custom-category-boxes">
-      {{#each @categories as |c|}}
+      {{#each @outletArgs.categories as |c|}}
         <a
           href={{c.url}}
           data-category-id={{c.id}}

--- a/javascripts/discourse/connectors/above-discovery-categories/custom-category-boxes.hbs
+++ b/javascripts/discourse/connectors/above-discovery-categories/custom-category-boxes.hbs
@@ -1,1 +1,0 @@
-<CustomCategoryBoxes @categories={{@outletArgs.categories}} />

--- a/javascripts/discourse/initializers/discourse-minimal-category-boxes.js
+++ b/javascripts/discourse/initializers/discourse-minimal-category-boxes.js
@@ -1,0 +1,6 @@
+import { apiInitializer } from "discourse/lib/api";
+import CustomCategoryBoxes from "../components/custom-category-boxes";
+
+export default apiInitializer("1.9.0", (api) => {
+  api.renderInPluginOutlet("above-discovery-categories", CustomCategoryBoxes);
+});


### PR DESCRIPTION
Why this change?

We are moving to glimmer components as a default in core so it makes
sense to start porting theme components to glimmer components as well.
Glimmer components can also be imported into other files making it
possible to pass the components directly to plugin APIs in the future.