### PR TITLE
DEV: Add system tests for theme components

### DIFF
--- a/spec/system/viewing_category_boxes_spec.rb
+++ b/spec/system/viewing_category_boxes_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe "Viewing category boxes", system: true do
+  fab!(:theme) { upload_theme_component }
+  fab!(:category_1) { Fabricate(:category, name: "New Category") }
+  fab!(:category_2) { Fabricate(:category, name: "Fresh Category") }
+
+  it "displays the category boxes" do
+    visit "/categories"
+
+    expect(page).to have_css(".custom-category-boxes")
+    expect(page).to have_selector(".category-box", count: 3)
+
+    expect(page).to have_selector(
+      ".category-box[data-category-id='#{category_1.id}'] .category-abbreviation",
+      exact_text: "Nc",
+    )
+
+    expect(page).to have_selector(
+      ".category-box[data-category-id='#{category_2.id}'] .category-abbreviation",
+      exact_text: "Fc",
+    )
+  end
+end


### PR DESCRIPTION
Relies on https://github.com/discourse/discourse/pull/23663

Adding a sample system test to the theme component. The system test is not run at the moment as part of CI at the moment as I am working on improving the `discourse-theme` github workflow to support the running of system tests.