### PR TITLE
DEV: Update .eslintrc globals instead of file specific globals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,8 @@
 {
-  "extends": "eslint-config-discourse"
+  "extends": "eslint-config-discourse",
+  "ignorePatterns": ["javascripts/vendor/*"],
+  "globals": {
+    "settings": "readonly",
+    "themePrefix": "readonly"
+  }
 }

--- a/javascripts/discourse/components/custom-category-boxes.js
+++ b/javascripts/discourse/components/custom-category-boxes.js
@@ -1,5 +1,3 @@
-/* global settings */
-
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 


### PR DESCRIPTION
Why this change?

`settings` and `themePrefix` are special globals for a theme so we need
to tell eslint to ignore them for now.