### PR TITLE
DEV: Use new `renderInOutlet` api

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,0 +1,1 @@
+< 3.2.0.beta2-dev: 1f8c3fcc27b1de3fe656dc9b5342987f5add9400

--- a/javascripts/discourse/components/custom-category-boxes.hbs
+++ b/javascripts/discourse/components/custom-category-boxes.hbs
@@ -25,6 +25,6 @@
       <CategoryBoxes @categories={{this.fifthCategories}} />
     {{/if}}
   {{else}}
-    <CategoryBoxes @categories={{@categories}} />
+    <CategoryBoxes @categories={{@outletArgs.categories}} />
   {{/if}}
 </div>

--- a/javascripts/discourse/connectors/above-discovery-categories/custom-category-boxes.hbs
+++ b/javascripts/discourse/connectors/above-discovery-categories/custom-category-boxes.hbs
@@ -1,1 +1,0 @@
-<CustomCategoryBoxes @categories={{@outletArgs.categories}} />

--- a/javascripts/discourse/initializers/initialize-category-boxes.js
+++ b/javascripts/discourse/initializers/initialize-category-boxes.js
@@ -1,0 +1,6 @@
+import { apiInitializer } from "discourse/lib/api";
+import CustomCategoryBoxes from "../components/custom-category-boxes";
+
+export default apiInitializer("1.14.0", (api) => {
+  api.renderInOutlet("above-discovery-categories", CustomCategoryBoxes);
+});


### PR DESCRIPTION
Why this change?

The renderInOutlet plugin API was introduced in Discourse core which we will prefer to use going forward.