### PR TITLE
DEV: Fix theme compatibility problem

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,1 +1,1 @@
-< 3.2.0.beta2-dev: 1f8c3fcc27b1de3fe656dc9b5342987f5add9400
+< 3.2.0.beta2: 1f8c3fcc27b1de3fe656dc9b5342987f5add9400


### PR DESCRIPTION
Technically < 3.2.0.beta2-dev is wrong cause it is a development version and there are many commits within that version. If Discourse core is on a commit that does not include the necessary changes required in 8304eefdbc2e8caf0fa4f3f8129d0e89152444df, the theme will break.