### PR TITLE
DEV: fix image size

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -191,8 +191,9 @@
       .category-logo {
         align-self: center;
         display: inline-block;
-        width: 132px;
-        height: 132px;
+        width: 100px;
+        height: 100px;
+        margin: 0;
         img {
           height: 100%;
           width: 100%;


### PR DESCRIPTION
This PR fixes the breaking of category logo images being displayed properly due to core changes.

**Before**
![CleanShot 2025-03-17 at 20 37 25@2x](https://github.com/user-attachments/assets/8f2d5a39-902a-4cf3-988f-cd702f38d441)

**After**
![CleanShot 2025-03-17 at 20 37 07@2x](https://github.com/user-attachments/assets/dc08b5cd-5b5d-4ef0-a7d7-9a671da0c6b8)
