### PR TITLE
UX: add spacing in desktop mode

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .custom-category-header {
   margin: 1em auto;
   display: inline-block;
@@ -40,6 +42,10 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+
+  @include viewport.from(sm) {
+    margin-top: var(--space-8);
+  }
 
   &:empty {
     display: none;


### PR DESCRIPTION
Meta report https://meta.discourse.org/t/css-regression-navigation-container-border-bottom-has-no-spacing-after-latest-update/377088/8
